### PR TITLE
gixsqlpp: always end CALL

### DIFF
--- a/libgixpp/TPESQLProcessing.cpp
+++ b/libgixpp/TPESQLProcessing.cpp
@@ -553,6 +553,8 @@ bool TPESQLProcessing::put_call(const ESQLCall &c, bool terminate_with_period)
 
 	if (terminate_with_period) {
 		lines.back() = lines.back() + ".";
+	} else {
+		lines.back() = lines.back() + " END-CALL";
 	}
 
 	for (auto ln : lines) {


### PR DESCRIPTION
to prevent leaking of / into exception clauses

"ideally" the `END-CALL` would be placed on the next line with the same indent as the `CALL`, but that PR primarily intend to fix the issue (note: not well tested, the additional characters may overflow fixed-form reference-format.