### PR TITLE
gixsql-autoconf: distribute generated files

### DIFF
--- a/deploy/installers/linux/gixsql-autoconf/libgixpp/Makefile.am
+++ b/deploy/installers/linux/gixsql-autoconf/libgixpp/Makefile.am
@@ -4,14 +4,13 @@ noinst_LIBRARIES = libgixpp.a
 libgixpp_a_SOURCES = ESQLCall.cpp  FileData.cpp  GixEsqlLexer.cpp  GixPreProcessor.cpp  ITransformationStep.cpp  MapFileReader.cpp  MapFileWriter.cpp  TPESQLProcessing.cpp  TPSourceConsolidation.cpp gix_esql_driver.cc gix_esql_parser.yy gix_esql_scanner.ll
 libgixpp_a_CXXFLAGS = -std=c++17 -I../libcpputils
 
-# sources to be build first (we actually want the bison generated header)
+# sources to be build first (we actually want the bison generated headers)
 BUILT_SOURCES = gix_esql_parser.cc
 
 # all generated source files, preventing the need for the user to have bison/flex installed
-EXTRA_DIST = gix_esql_parser.cc gix_esql_parser.hh gix_esql_scanner.cc
+EXTRA_DIST = gix_esql_parser.cc gix_esql_parser.hh location.hh gix_esql_scanner.cc
 
 AM_YFLAGS = -Wno-yacc -Wall -o gix_esql_parser.cc --defines=gix_esql_parser.hh
 AM_LFLAGS = -c++ -v --debug -o "gix_esql_scanner.cc"
 
-MAINTAINERCLEANFILES = gix_esql_parser.cc gix_esql_parser.hh gix_esql_scanner.cc
-CLEANFILES = location.hh
+MAINTAINERCLEANFILES = gix_esql_parser.cc gix_esql_parser.hh location.hh gix_esql_scanner.cc

--- a/deploy/installers/linux/gixsql-autoconf/libgixpp/Makefile.am
+++ b/deploy/installers/linux/gixsql-autoconf/libgixpp/Makefile.am
@@ -4,8 +4,14 @@ noinst_LIBRARIES = libgixpp.a
 libgixpp_a_SOURCES = ESQLCall.cpp  FileData.cpp  GixEsqlLexer.cpp  GixPreProcessor.cpp  ITransformationStep.cpp  MapFileReader.cpp  MapFileWriter.cpp  TPESQLProcessing.cpp  TPSourceConsolidation.cpp gix_esql_driver.cc gix_esql_parser.yy gix_esql_scanner.ll
 libgixpp_a_CXXFLAGS = -std=c++17 -I../libcpputils
 
-BUILT_SOURCES = gix_esql_parser.cc gix_esql_parser.hh gix_esql_scanner.cc
+# sources to be build first (we actually want the bison generated header)
+BUILT_SOURCES = gix_esql_parser.cc
+
+# all generated source files, preventing the need for the user to have bison/flex installed
+EXTRA_DIST = gix_esql_parser.cc gix_esql_parser.hh gix_esql_scanner.cc
+
 AM_YFLAGS = -Wno-yacc -Wall -o gix_esql_parser.cc --defines=gix_esql_parser.hh
 AM_LFLAGS = -c++ -v --debug -o "gix_esql_scanner.cc"
 
-CLEANFILES = gix_esql_parser.cc gix_esql_parser.hh gix_esql_scanner.cc location.hh
+MAINTAINERCLEANFILES = gix_esql_parser.cc gix_esql_parser.hh gix_esql_scanner.cc
+CLEANFILES = location.hh


### PR DESCRIPTION
The release tarball for gixsql misses the bison and flex generated files, so make tries to build them which is not unlikely to fail on "non-dev environments" - I've just got a note "doesn't build because yacc was not found, installed, still did not work, then searched on the net and additionally installed bison, now get a bison version mismatch".

The goal of this PR is to prevent that, now tested.