### PR TITLE
fix general errors not being printed anywhere

### DIFF
--- a/gixsql/libgixsql/Logger.h
+++ b/gixsql/libgixsql/Logger.h
@@ -54,7 +54,7 @@ private:
 #else
 
 #define LOG_DEBUG(file, func, format, ...)
-#define LOG_ERROR(format, ...) 
+#define LOG_ERROR(format, ...) fprintf(stderr, format, ##__VA_ARGS__)
 
 #define DECLARE_LOGGER(_l) 
 #define DECLARE_LOGGER_STATIC(_l)


### PR DESCRIPTION
This adjusts Logger.h to use the same definition like the drivers.

More notes, later moved to mridoni/gixsql#15 for tracking:

-----------------------------------

In general I'd suggest to _always_ use the logger for error handling and rename `GIXSQL_DEBUG_LOG ` to `GIXSQL_LOG` and `GIXSQL_DEBUG_LOG_ON` to `GIXSQL_DEBUG_LOGLEVEL`, defaulting to `ERR` (maybe have ´DBG` only be printed for `_DEBUG` - that would allow to toggle it to DBG during debugging, even if not compiled for that (or define the debug logging to nothing as it is done now).
For that part, which is not covered by this PR see also discussion in https://github.com/mridoni/gix/pull/25#issuecomment-1064165490.

Additional, also not covered because there is no level currently - if one compiles with `-D_DEBUG` (so logging is available in general) and logging in general is not activated by `GIXSQL_DEBUG_LOG_ON` - the error also goes to nirvana. With the log level I suggested errors would be default always be handled, if not _explicit_ turned OFF/0.