### PR TITLE
fix generation of DECLARE CURSOR FOR SELECT

### DIFF
--- a/libgixpp/TPESQLProcessing.cpp
+++ b/libgixpp/TPESQLProcessing.cpp
@@ -804,6 +804,9 @@ bool TPESQLProcessing::handle_esql_stmt(const ESQL_Command cmd, const cb_exec_sq
 				select_call.addParameter(stmt->cursor_hold, BY_VALUE);
 				select_call.addParameter(string_format("SQ%04d", stmt->sql_query_list_id), BY_REFERENCE);
 				
+				if (call_id.compare("GIXSQLCursorDeclareParams") == 0) // HACK
+					select_call.addParameter(stmt->host_list->size(), BY_VALUE);
+				
 				if (!put_call(select_call, stmt->period))
 					return false;
 			}


### PR DESCRIPTION
as a hack, works but looks bad

fixes the issue mentioned in https://github.com/mridoni/gix/issues/50#issuecomment-1072590214

@mridoni I don't know:

* if there are more functions which needs this
* if the codegen should end there and not where the literal is in (around line 530)

In any case: test.cpp doesn't look like it could be compiled, because it uses a different signature.