### PR TITLE
DbInterfacePGSQL::get_resultset_value C string handling

### DIFF
--- a/gixsql/libgixsql-pgsql/DbInterfacePGSQL.cpp
+++ b/gixsql/libgixsql-pgsql/DbInterfacePGSQL.cpp
@@ -563,7 +563,7 @@ bool DbInterfacePGSQL::get_resultset_value(ICursor *c, int row, int col, char *b
 		*value_len = to_length;
 		memcpy(bfr, tmp_bfr, to_length);
 		if (to_length < bfrlen) {
-			memset(bfr + to_length, 0, bfrlen - to_lenght);
+			memset(bfr + to_length, 0, bfrlen - to_length);
 		}
 		PQfreemem(tmp_bfr);
 	}


### PR DESCRIPTION
removed unnecessary calls to C string functions found in #84 (get length one time, then use that)

Note: I did not checked other drivers, the same may apply there, too; I did not run any tests with the code, but wanted to drop it instead of forgetting about it, because this may lead to a performance increase of 0.6% ... (still nice when getting it "nearly for free" and making the code for string and binary similar on the way, too)